### PR TITLE
Autoprefixer queries from config

### DIFF
--- a/gulp-tasks/gulp-css.js
+++ b/gulp-tasks/gulp-css.js
@@ -41,7 +41,7 @@
         sourceComments: config.cssConfig.sourceComments,
         includePaths: require('node-normalize-scss').with(config.cssConfig.includePaths)
       }).on('error', sass.logError))
-      .pipe(prefix(['last 1 version', '> 1%', 'ie 10']))
+      .pipe(prefix(config.cssConfig.autoPrefixerBrowsers))
       .pipe(sourcemaps.init())
       .pipe(cleanCSS())
       .pipe(sourcemaps.write((config.cssConfig.sourceMapEmbed) ? null : './'))


### PR DESCRIPTION
Autoprefixer queries were hard coded and ignore config, this change uses the info from the config file